### PR TITLE
Improve the acceptable error

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -220,7 +219,7 @@ func TestPostWithAcceptableError(t *testing.T) {
 
 	resourceError = errors.New("acceptable error")
 
-	resources.AcceptableError = reflect.TypeOf(resourceError)
+	resources.AcceptableError = func(err error) bool { return err == resourceError }
 	defer clearResourceErrors()
 
 	res := req(postBody(t, body))
@@ -416,6 +415,6 @@ func assertNoErr(err error) {
 }
 
 func clearResourceErrors() {
-	resources.AcceptableError = nil
+	resources.AcceptableError = func(error) bool { return false }
 	resourceError = nil
 }


### PR DESCRIPTION
There is two type of validation error that returned by `db.Create`.
This change support detect multiple type of errors.

Close #13.